### PR TITLE
Support to exclude providing Target type input

### DIFF
--- a/files/providers/wls_file_persistence_store/create_modify.py.erb
+++ b/files/providers/wls_file_persistence_store/create_modify.py.erb
@@ -18,7 +18,11 @@ try:
 
     cd('/FileStores/' + name)
     set_attribute_value('Directory', directory, use_default_value_when_empty)
-    set('Targets', jarray.array([ObjectName('com.bea:Name=' + target + ',Type=' + targettype)], ObjectName))
+    if not targettype:
+        print('target type is not passed, So not changeing the Target')
+    else:
+        set('Targets', jarray.array([ObjectName('com.bea:Name=' + target + ',Type=' + targettype)], ObjectName))    
+
 
     save()
     activate()


### PR DESCRIPTION
SOA domain creates persistence store with target type BAM and SOA server in different order everytime.
So we need to be able to exclude the target for problematic persistence store files.